### PR TITLE
fix(env-vars): add back Business Central env vars

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,14 @@ inputs:
     description: MUI_LICENSE_KEY
     required: false
     default: ""
+  BC_CLIENT_SECRET_V2:
+    description: BC_CLIENT_SECRET_V2
+    required: false
+    default: ""
+  BC_SUBSCRIPTION_KEY:
+    description: BC_SUBSCRIPTION_KEY
+    required: false
+    default: ""
 runs:
   using: composite
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -73,5 +73,7 @@ runs:
           REPOSITORY=${{ inputs.REPOSITORY }}
           SHEETJS_TOKEN=${{ inputs.SHEETJS_TOKEN }}
           MUI_LICENSE_KEY=${{ inputs.MUI_LICENSE_KEY }}
+          BC_CLIENT_SECRET_V2=${{ inputs.BC_CLIENT_SECRET_V2 }}
+          BC_SUBSCRIPTION_KEY=${{ inputs.BC_SUBSCRIPTION_KEY }}
         secrets: |
           GIT_AUTH_TOKEN=${{ inputs.ADMIN_PAT }}


### PR DESCRIPTION
Adds back support for Business Central env vars to the ghcr image build process. Cf. [QUB-86](https://bisonok.atlassian.net/browse/QUB-86) for more details.

[QUB-86]: https://bisonok.atlassian.net/browse/QUB-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ